### PR TITLE
Update fetcher for APIM 4.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ],
-  "prConcurrentLimit": 3,
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
-    }
-  ]
+    "extends": ["github>gravitee-io/renovate-config:lib"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -24,19 +24,22 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>22.0.2</version>
     </parent>
 
     <groupId>io.gravitee.fetcher</groupId>
     <artifactId>gravitee-fetcher-github</artifactId>
-    <version>1.7.0</version>
+    <version>2.0.0-upgrade-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Fetcher - GitHub</name>
 
     <properties>
-        <gravitee-bom.version>1.1</gravitee-bom.version>
-        <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <gravitee-bom.version>6.0.39</gravitee-bom.version>
+        <gravitee-common.version>3.4.1</gravitee-common.version>
+        <gravitee-fetcher-api.version>2.0.0</gravitee-fetcher-api.version>
+        <wiremock.version>3.3.1</wiremock.version>
+
+        <maven-assembly-plugin.version>3.5.0</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/fetchers</publish-folder-path>
     </properties>
@@ -55,6 +58,14 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Gravitee.io -->
+        <dependency>
+            <groupId>io.gravitee.common</groupId>
+            <artifactId>gravitee-common</artifactId>
+            <version>${gravitee-common.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.gravitee.fetcher</groupId>
             <artifactId>gravitee-fetcher-api</artifactId>
@@ -100,10 +111,17 @@
             </exclusions>
         </dependency>
 
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -112,16 +130,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>${wiremock.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock</artifactId>
-            <version>2.27.2</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
@@ -160,19 +179,6 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/assembly/fetcher-assembly.xml
+++ b/src/assembly/fetcher-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -39,7 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.support.CronSequenceGenerator;
+import org.springframework.scheduling.support.CronExpression;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
@@ -178,7 +178,7 @@ public class GitHubFetcher implements FilesFetcher {
 
         if (gitHubFetcherConfiguration.isAutoFetch() && gitHubFetcherConfiguration.getFetchCron() != null) {
             try {
-                new CronSequenceGenerator(gitHubFetcherConfiguration.getFetchCron());
+                CronExpression.parse(gitHubFetcherConfiguration.getFetchCron());
             } catch (IllegalArgumentException e) {
                 throw new FetcherException("Cron expression is invalid", e);
             }

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcherConfiguration.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcherConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcherConfiguration.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcherConfiguration.java
@@ -18,11 +18,15 @@ package io.gravitee.fetcher.github;
 import io.gravitee.fetcher.api.FetcherConfiguration;
 import io.gravitee.fetcher.api.FilepathAwareFetcherConfiguration;
 import io.gravitee.fetcher.api.Sensitive;
+import lombok.Getter;
+import lombok.Setter;
 
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@Getter
+@Setter
 public class GitHubFetcherConfiguration implements FetcherConfiguration, FilepathAwareFetcherConfiguration {
 
     private String githubUrl;
@@ -41,96 +45,4 @@ public class GitHubFetcherConfiguration implements FetcherConfiguration, Filepat
     private String fetchCron;
 
     private boolean autoFetch = false;
-
-    public String getGithubUrl() {
-        return githubUrl;
-    }
-
-    public void setGithubUrl(String githubUrl) {
-        this.githubUrl = githubUrl;
-    }
-
-    public boolean isUseSystemProxy() {
-        return useSystemProxy;
-    }
-
-    public void setUseSystemProxy(boolean useSystemProxy) {
-        this.useSystemProxy = useSystemProxy;
-    }
-
-    public String getOwner() {
-        return owner;
-    }
-
-    public void setOwner(String owner) {
-        this.owner = owner;
-    }
-
-    public String getRepository() {
-        return repository;
-    }
-
-    public void setRepository(String repository) {
-        this.repository = repository;
-    }
-
-    public String getBranchOrTag() {
-        return branchOrTag;
-    }
-
-    public void setBranchOrTag(String branchOrTag) {
-        this.branchOrTag = branchOrTag;
-    }
-
-    @Override
-    public String getFilepath() {
-        return filepath;
-    }
-
-    @Override
-    public void setFilepath(String filepath) {
-        this.filepath = filepath;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public String getPersonalAccessToken() {
-        return personalAccessToken;
-    }
-
-    public void setPersonalAccessToken(String personalAccessToken) {
-        this.personalAccessToken = personalAccessToken;
-    }
-
-    public String getEditLink() {
-        return editLink;
-    }
-
-    public void setEditLink(String editLink) {
-        this.editLink = editLink;
-    }
-
-    @Override
-    public String getFetchCron() {
-        return fetchCron;
-    }
-
-    public void setFetchCron(String fetchCron) {
-        this.fetchCron = fetchCron;
-    }
-
-    @Override
-    public boolean isAutoFetch() {
-        return autoFetch;
-    }
-
-    public void setAutoFetch(boolean autoFetch) {
-        this.autoFetch = autoFetch;
-    }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,70 +1,63 @@
 {
-  "type": "object",
-  "title": "github",
-  "properties": {
-    "githubUrl": {
-      "title": "GitHub URL",
-      "type": "string",
-      "default": "https://api.github.com"
-    },
-    "useSystemProxy": {
-      "title": "Use system proxy",
-      "description": "Use the system proxy configured by your administrator.",
-      "type": "boolean"
-    },
-    "owner": {
-      "title": "Repository Owner",
-      "description": "Owner of the repository",
-      "type": "string"
-    },
-    "repository": {
-      "title": "Repository",
-      "type": "string"
-    },
-    "branchOrTag": {
-      "title": "Ref",
-      "description": "Branch name, tag or sha1 (e.g. master). If empty, we use the default branch.",
-      "type": "string"
-    },
-    "filepath": {
-      "title": "Filepath",
-      "description": "The path to the file to fetch (e.g. /docs/main/README.md)",
-      "type": "string"
-    },
-    "username": {
-      "title": "Username",
-      "description": "Username used to authenticate the request",
-      "type": "string"
-    },
-    "personalAccessToken": {
-      "title": "Personal Access Token",
-      "description": "Create your personal access token here: https://github.com/settings/tokens",
-      "type": "string"
-    },
-    "autoFetch": {
-      "title": "Auto Fetch",
-      "description": "Trigger periodic update",
-      "type": "boolean",
-      "default": false
-    },
-    "fetchCron": {
-      "title": "Update frequency",
-      "description": "Define update frequency using Crontab pattern.<BR><B>Note:</B> Platform administrator may have configure a max frequency that you cannot exceed",
-      "type": "string"
-    }
-  },
-  "required": [
-    "githubUrl",
-    "owner",
-    "repository"
-  ],
-  "if": {
+    "type": "object",
+    "title": "github",
     "properties": {
-      "autoFetch": { "const": true }
-    }
-  },
-  "then": { "required": ["fetchCron"] }
+        "githubUrl": {
+            "title": "GitHub URL",
+            "type": "string",
+            "default": "https://api.github.com"
+        },
+        "useSystemProxy": {
+            "title": "Use system proxy",
+            "description": "Use the system proxy configured by your administrator.",
+            "type": "boolean"
+        },
+        "owner": {
+            "title": "Repository Owner",
+            "description": "Owner of the repository",
+            "type": "string"
+        },
+        "repository": {
+            "title": "Repository",
+            "type": "string"
+        },
+        "branchOrTag": {
+            "title": "Ref",
+            "description": "Branch name, tag or sha1 (e.g. master). If empty, we use the default branch.",
+            "type": "string"
+        },
+        "filepath": {
+            "title": "Filepath",
+            "description": "The path to the file to fetch (e.g. /docs/main/README.md)",
+            "type": "string"
+        },
+        "username": {
+            "title": "Username",
+            "description": "Username used to authenticate the request",
+            "type": "string"
+        },
+        "personalAccessToken": {
+            "title": "Personal Access Token",
+            "description": "Create your personal access token here: https://github.com/settings/tokens",
+            "type": "string"
+        },
+        "autoFetch": {
+            "title": "Auto Fetch",
+            "description": "Trigger periodic update",
+            "type": "boolean",
+            "default": false
+        },
+        "fetchCron": {
+            "title": "Update frequency",
+            "description": "Define update frequency using Crontab pattern.<BR><B>Note:</B> Platform administrator may have configure a max frequency that you cannot exceed",
+            "type": "string"
+        }
+    },
+    "required": ["githubUrl", "owner", "repository"],
+    "if": {
+        "properties": {
+            "autoFetch": { "const": true }
+        }
+    },
+    "then": { "required": ["fetchCron"] }
 }
-
-
-

--- a/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FetchTest.java
+++ b/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FetchTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_TreeTest.java
+++ b/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_TreeTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4957
https://github.com/gravitee-io/issues/issues/9733

**Description**

Starting with APIM 4.3, Spring 6.1.8 is used. But in this version, the `CronSequenceGenerator` has been replaced by `CronExpression`
We need to update every fetcher libs and plugins to handle this change.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-upgrade-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-github/2.0.0-upgrade-SNAPSHOT/gravitee-fetcher-github-2.0.0-upgrade-SNAPSHOT.zip)
  <!-- Version placeholder end -->
