### PR TITLE
Remove wiremock from final ZIP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
                     <artifactId>guava</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
**Issue**

N/A

**Description**

Remove wiremock from final ZIP
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.1-clean-up-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-github/2.0.1-clean-up-dependencies-SNAPSHOT/gravitee-fetcher-github-2.0.1-clean-up-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
