### PR TITLE
feat: fallback to rawcontent if file is too heavy with api.github.com (>1MB)

### DIFF
--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -97,25 +97,53 @@ public class GitHubFetcher implements FilesFetcher {
     @Override
     public Resource fetch() throws FetcherException {
         checkRequiredFields(true);
-        JsonNode jsonNode = this.request(getFetchUrl());
 
-        final Resource resource = new Resource();
-        if (jsonNode != null) {
-            final Map<String, Object> metadata = mapper.convertValue(jsonNode, Map.class);
-            final Object content = metadata.remove("content");
-            if (content != null) {
-                final String contentAsBase64 = String.valueOf(content).replaceAll("\\n", "");
+        try {
+            Buffer buffer = fetchContent(getFetchUrl()).join();
+            if (buffer == null || buffer.length() == 0) {
+                logger.warn("Something goes wrong, GitHub responds with a status 200 but the content is empty.");
+                return null;
+            }
+
+            JsonNode jsonNode = mapper.readTree(buffer.getBytes());
+            final Resource resource = new Resource();
+
+            // 2. On vérifie le champ "content"
+            JsonNode contentNode = jsonNode.get("content");
+            if (contentNode != null && !contentNode.asText().isEmpty()) {
+                final String contentAsBase64 = contentNode.asText().replaceAll("\\n", "");
                 byte[] decodedContent = Base64.getDecoder().decode(contentAsBase64);
                 resource.setContent(new ByteArrayInputStream(decodedContent));
+            } else {
+                JsonNode downloadUrlNode = jsonNode.get("download_url");
+                if (downloadUrlNode != null && !downloadUrlNode.asText().isEmpty()) {
+                    String downloadUrl = downloadUrlNode.asText();
+                    logger.info("File exceeds GitHub API size limit. Falling back to raw download: {}", downloadUrl);
+                    Buffer rawBuffer = fetchContent(downloadUrl).join();
+                    resource.setContent(new ByteArrayInputStream(rawBuffer.getBytes()));
+                } else {
+                    throw new FetcherException("No content and no download_url found in GitHub response.", null);
+                }
             }
-            final Object htmlUrl = metadata.get("html_url");
-            if (htmlUrl != null) {
-                metadata.put(EDIT_URL_PROPERTY_KEY, String.valueOf(htmlUrl).replace("blob", "edit"));
-            }
+
+            // 3. Construction des métadonnées pour le portail
+            final Map<String, Object> metadata = new HashMap<>();
             metadata.put(PROVIDER_NAME_PROPERTY_KEY, "GitHub");
+
+            JsonNode htmlUrlNode = jsonNode.get("html_url");
+            if (htmlUrlNode != null) {
+                metadata.put(EDIT_URL_PROPERTY_KEY, htmlUrlNode.asText().replace("blob", "edit"));
+            }
+
             resource.setMetadata(metadata);
+            return resource;
+        } catch (Exception ex) {
+            if (ex.getCause() != null && ex.getCause() instanceof ResourceNotFoundException e) {
+                throw e;
+            }
+            logger.error(ex.getMessage(), ex);
+            throw new FetcherException("Unable to fetch GitHub content (" + ex.getMessage() + ")", ex);
         }
-        return resource;
     }
 
     @Override

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -102,13 +102,12 @@ public class GitHubFetcher implements FilesFetcher {
             Buffer buffer = fetchContent(getFetchUrl()).join();
             if (buffer == null || buffer.length() == 0) {
                 logger.warn("Something goes wrong, GitHub responds with a status 200 but the content is empty.");
-                return null;
+                return new Resource();
             }
 
             JsonNode jsonNode = mapper.readTree(buffer.getBytes());
             final Resource resource = new Resource();
 
-            // 2. On vérifie le champ "content"
             JsonNode contentNode = jsonNode.get("content");
             if (contentNode != null && !contentNode.asText().isEmpty()) {
                 final String contentAsBase64 = contentNode.asText().replaceAll("\\n", "");
@@ -126,13 +125,14 @@ public class GitHubFetcher implements FilesFetcher {
                 }
             }
 
-            // 3. Construction des métadonnées pour le portail
-            final Map<String, Object> metadata = new HashMap<>();
+            // 3. Build metadata for the portal
+            final Map<String, Object> metadata = mapper.convertValue(jsonNode, Map.class);
+            metadata.remove("content");
             metadata.put(PROVIDER_NAME_PROPERTY_KEY, "GitHub");
 
-            JsonNode htmlUrlNode = jsonNode.get("html_url");
-            if (htmlUrlNode != null) {
-                metadata.put(EDIT_URL_PROPERTY_KEY, htmlUrlNode.asText().replace("blob", "edit"));
+            final Object htmlUrl = metadata.get("html_url");
+            if (htmlUrl != null) {
+                metadata.put(EDIT_URL_PROPERTY_KEY, String.valueOf(htmlUrl).replace("blob", "edit"));
             }
 
             resource.setMetadata(metadata);

--- a/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FetchTest.java
+++ b/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FetchTest.java
@@ -82,9 +82,8 @@ class GitHubFetcher_FetchTest {
         ReflectionTestUtils.setField(fetcher, "gitHubFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
-        // On vérifie directement que le résultat du fetch() est null
-        // plutôt que d'essayer d'appeler .getContent() dessus !
-        assertThat(fetcher.fetch()).isNull();
+        InputStream fetch = fetcher.fetch().getContent();
+        assertThat(fetch).isNull();
     }
 
     @Test

--- a/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FetchTest.java
+++ b/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FetchTest.java
@@ -53,7 +53,7 @@ class GitHubFetcher_FetchTest {
     }
 
     @Test
-    public void shouldNotFetchWithoutContent() throws FetcherException {
+    public void shouldThrowExceptionWithoutContent() throws FetcherException {
         wiremock.stubFor(
             get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1"))
                 .willReturn(aResponse().withStatus(200).withBody("{\"key\": \"value\"}"))
@@ -67,9 +67,7 @@ class GitHubFetcher_FetchTest {
         ReflectionTestUtils.setField(fetcher, "gitHubFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
-        InputStream fetch = fetcher.fetch().getContent();
-
-        assertThat(fetch).isNull();
+        assertThatThrownBy(fetcher::fetch).isInstanceOf(FetcherException.class).hasMessageContaining("No content and no download_url");
     }
 
     @Test
@@ -84,8 +82,9 @@ class GitHubFetcher_FetchTest {
         ReflectionTestUtils.setField(fetcher, "gitHubFetcherConfiguration", config);
         ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
 
-        InputStream fetch = fetcher.fetch().getContent();
-        assertThat(fetch).isNull();
+        // On vérifie directement que le résultat du fetch() est null
+        // plutôt que d'essayer d'appeler .getContent() dessus !
+        assertThat(fetcher.fetch()).isNull();
     }
 
     @Test
@@ -102,7 +101,7 @@ class GitHubFetcher_FetchTest {
         config.setBranchOrTag("sha1");
         ReflectionTestUtils.setField(fetcher, "gitHubFetcherConfiguration", config);
 
-        assertThatThrownBy(fetcher::fetch).hasMessage("Illegal base64 character 20");
+        assertThatThrownBy(fetcher::fetch).hasMessageContaining("Illegal base64 character 20");
     }
 
     @Test
@@ -131,6 +130,39 @@ class GitHubFetcher_FetchTest {
         fetch.read(bytes, 0, n);
         String decoded = new String(bytes, StandardCharsets.UTF_8);
         assertThat(decoded).isEqualTo(content);
+    }
+
+    @Test
+    public void shouldFetchRawContentWhenBase64IsEmpty() throws Exception {
+        String rawContent = "This is a massive swagger file bypassing the GitHub limit!";
+        String downloadUrlPath = "/raw/owner/myrepo/master/path/to/file";
+        String fullDownloadUrl = wiremock.baseUrl() + downloadUrlPath;
+
+        wiremock.stubFor(
+            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1"))
+                .willReturn(aResponse().withStatus(200).withBody("{\"content\": \"\", \"download_url\": \"" + fullDownloadUrl + "\"}"))
+        );
+
+        wiremock.stubFor(get(urlEqualTo(downloadUrlPath)).willReturn(aResponse().withStatus(200).withBody(rawContent)));
+
+        GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
+        config.setOwner("owner");
+        config.setRepository("myrepo");
+        config.setFilepath("/path/to/file");
+        config.setGithubUrl(wiremock.baseUrl());
+        config.setBranchOrTag("sha1");
+        ReflectionTestUtils.setField(fetcher, "gitHubFetcherConfiguration", config);
+        ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
+
+        InputStream fetch = fetcher.fetch().getContent();
+
+        assertThat(fetch).isNotNull();
+        int n = fetch.available();
+        byte[] bytes = new byte[n];
+        fetch.read(bytes, 0, n);
+        String decoded = new String(bytes, StandardCharsets.UTF_8);
+
+        assertThat(decoded).isEqualTo(rawContent);
     }
 
     @Test


### PR DESCRIPTION
**Issue**

N/A

**Description**

We face an issue while importing swaggers through the `gravitee-io/gravitee-fetcher-github` plugin. Because of the limit size on `api.github` that remove content over 1MB. The idea of this PR is to switch to `raw.githubusercontent.com` (`download_url` key) if the content is too heavy.

**Additional context**

How to reproduce: 
- Use a json file that is over 1MB size
- Try to synchronize it with gravitee-fetcher-github plugin
- Check logs on Gravitee Kubernetes Operator:
```
{
  "level": "error",
  "timestamp": 1776957897.349202,
  "message": "Aborting reconcile",
  "controller": "apidefinition",
  "controllerGroup": "gravitee.io",
  "controllerKind": "ApiDefinition",
  "ApiDefinition": {
    "namespace": "gravitee"
  },
  "namespace": "gravitee",
  "reconcileID": "6cd1e1e0-8a14-482a-81ca-549a3a29321a",
  "error": "request [PUT] http://gravitee-gke-development-europe-apim3-api.gravitee.svc.cluster.local:83/management/organizations/DEFAULT/environments/DEFAULT/apis/import?definitionVersion=2.0.0 failed with status 400 (Malformed descriptor)"
}
```
