### PR TITLE
feat: upgrade to vertx 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.18.1
+    gravitee: gravitee-io/gravitee@5.10.2
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,3 @@
+lombok.addLombokGeneratedAnnotation = true
+config.stopBubbling = true
+lombok.log.custom.declaration = org.slf4j.Logger io.gravitee.node.logging.NodeLoggerFactory.getLogger(TYPE)

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.5.1</version>
+        <version>24.0.2</version>
     </parent>
 
     <groupId>io.gravitee.fetcher</groupId>
@@ -34,8 +34,8 @@
     <name>Gravitee.io APIM - Fetcher - GitHub</name>
 
     <properties>
-        <gravitee-bom.version>6.0.64</gravitee-bom.version>
-        <gravitee-common.version>3.4.2</gravitee-common.version>
+        <gravitee-bom.version>9.0.2</gravitee-bom.version>
+        <gravitee-common.version>5.0.0</gravitee-common.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
         <wiremock.version>3.13.2</wiremock.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <gravitee-bom.version>9.0.2</gravitee-bom.version>
         <gravitee-common.version>5.0.0</gravitee-common.version>
         <gravitee-fetcher-api.version>2.1.0</gravitee-fetcher-api.version>
+        <gravitee-node.version>9.2.1</gravitee-node.version>
         <wiremock.version>3.13.2</wiremock.version>
 
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
@@ -70,6 +71,12 @@
             <groupId>io.gravitee.fetcher</groupId>
             <artifactId>gravitee-fetcher-api</artifactId>
             <version>${gravitee-fetcher-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-logging</artifactId>
+            <version>${gravitee-node.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -243,7 +244,9 @@ public class GitHubFetcher implements FilesFetcher {
             .setTrustAll(true)
             .setKeepAlive(false)
             .setTcpKeepAlive(false)
-            .setConnectTimeout(httpClientTimeout);
+            .setConnectTimeout(httpClientTimeout)
+            .setIdleTimeout(httpClientTimeout)
+            .setIdleTimeoutUnit(TimeUnit.MILLISECONDS);
 
         final PoolOptions poolOptions = new PoolOptions().setHttp1MaxSize(1);
 

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -221,12 +222,13 @@ public class GitHubFetcher implements FilesFetcher {
 
             return new ObjectMapper().readTree(buffer.getBytes());
         } catch (Exception ex) {
-            if (ex.getCause() != null && ex.getCause() instanceof ResourceNotFoundException e) {
-                throw e;
+            Throwable cause = ex instanceof CompletionException && ex.getCause() != null ? ex.getCause() : ex;
+            if (cause instanceof ResourceNotFoundException resourceNotFoundException) {
+                throw resourceNotFoundException;
             }
 
-            log.error(ex.getMessage(), ex);
-            throw new FetcherException("Unable to fetch GitHub content (" + ex.getMessage() + ")", ex);
+            log.error(cause.getMessage(), cause);
+            throw new FetcherException("Unable to fetch GitHub content (" + cause.getMessage() + ")", cause);
         }
     }
 
@@ -315,7 +317,6 @@ public class GitHubFetcher implements FilesFetcher {
                 .onSuccess(promise::complete)
                 .onFailure(promise::fail);
         } catch (Exception ex) {
-            log.error("Unable to fetch content using HTTP", ex);
             promise.fail(ex);
         }
 

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -32,8 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.support.CronExpression;
@@ -42,9 +41,9 @@ import org.springframework.scheduling.support.CronExpression;
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
+@CustomLog
 public class GitHubFetcher implements FilesFetcher {
 
-    private static final Logger logger = LoggerFactory.getLogger(GitHubFetcher.class);
     private static final String HTTPS_SCHEME = "https";
     private static final String VERSION_HEADER = "application/vnd.github.v3+json";
     private GitHubFetcherConfiguration gitHubFetcherConfiguration;
@@ -216,7 +215,7 @@ public class GitHubFetcher implements FilesFetcher {
         try {
             Buffer buffer = fetchContent(url).join();
             if (buffer == null || buffer.length() == 0) {
-                logger.warn("Something goes wrong, GitHub responds with a status 200 but the content is empty.");
+                log.warn("Something goes wrong, GitHub responds with a status 200 but the content is empty.");
                 return null;
             }
 
@@ -226,7 +225,7 @@ public class GitHubFetcher implements FilesFetcher {
                 throw e;
             }
 
-            logger.error(ex.getMessage(), ex);
+            log.error(ex.getMessage(), ex);
             throw new FetcherException("Unable to fetch GitHub content (" + ex.getMessage() + ")", ex);
         }
     }
@@ -316,7 +315,7 @@ public class GitHubFetcher implements FilesFetcher {
                 .onSuccess(promise::complete)
                 .onFailure(promise::fail);
         } catch (Exception ex) {
-            logger.error("Unable to fetch content using HTTP", ex);
+            log.error("Unable to fetch content using HTTP", ex);
             promise.fail(ex);
         }
 

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.utils.UUID;
 import io.gravitee.fetcher.api.*;
-import io.vertx.core.Handler;
+import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
@@ -164,10 +164,8 @@ public class GitHubFetcher implements FilesFetcher {
             gitHubFetcherConfiguration.getOwner().isEmpty() ||
             gitHubFetcherConfiguration.getRepository() == null ||
             gitHubFetcherConfiguration.getRepository().isEmpty() ||
-            (
-                gitHubFetcherConfiguration.isAutoFetch() &&
-                (gitHubFetcherConfiguration.getFetchCron() == null || gitHubFetcherConfiguration.getFetchCron().isEmpty())
-            ) ||
+            (gitHubFetcherConfiguration.isAutoFetch() &&
+                (gitHubFetcherConfiguration.getFetchCron() == null || gitHubFetcherConfiguration.getFetchCron().isEmpty())) ||
             (checkFilepath && (gitHubFetcherConfiguration.getFilepath() == null || gitHubFetcherConfiguration.getFilepath().isEmpty()))
         ) {
             throw new FetcherException("Some required configuration attributes are missing.", null);
@@ -192,11 +190,9 @@ public class GitHubFetcher implements FilesFetcher {
             gitHubFetcherConfiguration.getRepository() +
             "/contents" +
             gitHubFetcherConfiguration.getFilepath() +
-            (
-                gitHubFetcherConfiguration.getBranchOrTag() != null && !gitHubFetcherConfiguration.getBranchOrTag().isEmpty()
+            (gitHubFetcherConfiguration.getBranchOrTag() != null && !gitHubFetcherConfiguration.getBranchOrTag().isEmpty()
                     ? ("?ref=" + gitHubFetcherConfiguration.getBranchOrTag())
-                    : ""
-            )
+                    : "")
         );
     }
 
@@ -209,11 +205,9 @@ public class GitHubFetcher implements FilesFetcher {
             "/" +
             gitHubFetcherConfiguration.getRepository() +
             "/git/trees/" +
-            (
-                gitHubFetcherConfiguration.getBranchOrTag() != null && !gitHubFetcherConfiguration.getBranchOrTag().isEmpty()
+            (gitHubFetcherConfiguration.getBranchOrTag() != null && !gitHubFetcherConfiguration.getBranchOrTag().isEmpty()
                     ? (gitHubFetcherConfiguration.getBranchOrTag())
-                    : "master"
-            ) +
+                    : "master") +
             "?recursive=1"
         );
     }
@@ -246,10 +240,11 @@ public class GitHubFetcher implements FilesFetcher {
         final HttpClientOptions options = new HttpClientOptions()
             .setSsl(ssl)
             .setTrustAll(true)
-            .setMaxPoolSize(1)
             .setKeepAlive(false)
             .setTcpKeepAlive(false)
             .setConnectTimeout(httpClientTimeout);
+
+        final PoolOptions poolOptions = new PoolOptions().setHttp1MaxSize(1);
 
         if (gitHubFetcherConfiguration.isUseSystemProxy()) {
             ProxyOptions proxyOptions = new ProxyOptions();
@@ -268,7 +263,9 @@ public class GitHubFetcher implements FilesFetcher {
             options.setProxyOptions(proxyOptions);
         }
 
-        final HttpClient httpClient = vertx.createHttpClient(options);
+        final HttpClient httpClient = vertx.createHttpClient(options, poolOptions);
+        promise.future().onComplete(ar -> httpClient.close());
+
         final int port = requestUri.getPort() != -1 ? requestUri.getPort() : (HTTPS_SCHEME.equals(requestUri.getScheme()) ? 443 : 80);
 
         try {
@@ -296,72 +293,28 @@ public class GitHubFetcher implements FilesFetcher {
 
             httpClient
                 .request(reqOptions)
-                .onFailure(
-                    new Handler<Throwable>() {
-                        @Override
-                        public void handle(Throwable throwable) {
-                            promise.fail(throwable);
-
-                            // Close client
-                            httpClient.close();
-                        }
+                .compose(HttpClientRequest::send)
+                .compose(response -> {
+                    if (response.statusCode() == HttpStatusCode.OK_200) {
+                        return response.body();
+                    } else if (response.statusCode() == HttpStatusCode.NOT_FOUND_404) {
+                        return Future.failedFuture(new ResourceNotFoundException("Unable to fetch '" + url, null));
+                    } else {
+                        return Future.failedFuture(
+                            new FetcherException(
+                                "Unable to fetch '" +
+                                    url +
+                                    "'. Status code: " +
+                                    response.statusCode() +
+                                    ". Message: " +
+                                    response.statusMessage(),
+                                null
+                            )
+                        );
                     }
-                )
-                .onSuccess(
-                    new Handler<HttpClientRequest>() {
-                        @Override
-                        public void handle(HttpClientRequest request) {
-                            request.response(asyncResponse -> {
-                                if (asyncResponse.failed()) {
-                                    promise.fail(asyncResponse.cause());
-
-                                    // Close client
-                                    httpClient.close();
-                                } else {
-                                    HttpClientResponse response = asyncResponse.result();
-                                    if (response.statusCode() == HttpStatusCode.OK_200) {
-                                        response.bodyHandler(buffer -> {
-                                            promise.complete(buffer);
-
-                                            // Close client
-                                            httpClient.close();
-                                        });
-                                    } else if (response.statusCode() == HttpStatusCode.NOT_FOUND_404) {
-                                        promise.fail(new ResourceNotFoundException("Unable to fetch '" + url, null));
-                                    } else {
-                                        promise.fail(
-                                            new FetcherException(
-                                                "Unable to fetch '" +
-                                                url +
-                                                "'. Status code: " +
-                                                response.statusCode() +
-                                                ". Message: " +
-                                                response.statusMessage(),
-                                                null
-                                            )
-                                        );
-
-                                        // Close client
-                                        httpClient.close();
-                                    }
-                                }
-                            });
-
-                            request.exceptionHandler(throwable -> {
-                                try {
-                                    promise.fail(throwable);
-
-                                    // Close client
-                                    httpClient.close();
-                                } catch (IllegalStateException ise) {
-                                    // Do not take care about exception when closing client
-                                }
-                            });
-
-                            request.end();
-                        }
-                    }
-                );
+                })
+                .onSuccess(promise::complete)
+                .onFailure(promise::fail);
         } catch (Exception ex) {
             logger.error("Unable to fetch content using HTTP", ex);
             promise.fail(ex);

--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -172,7 +172,7 @@ public class GitHubFetcher implements FilesFetcher {
             throw new FetcherException("Some required configuration attributes are missing.", null);
         }
 
-        if (gitHubFetcherConfiguration.isAutoFetch() && gitHubFetcherConfiguration.getFetchCron() != null) {
+        if (gitHubFetcherConfiguration.isAutoFetch()) {
             try {
                 CronExpression.parse(gitHubFetcherConfiguration.getFetchCron());
             } catch (IllegalArgumentException e) {
@@ -298,25 +298,7 @@ public class GitHubFetcher implements FilesFetcher {
             httpClient
                 .request(reqOptions)
                 .compose(HttpClientRequest::send)
-                .compose(response -> {
-                    if (response.statusCode() == HttpStatusCode.OK_200) {
-                        return response.body();
-                    } else if (response.statusCode() == HttpStatusCode.NOT_FOUND_404) {
-                        return Future.failedFuture(new ResourceNotFoundException("Unable to fetch '" + url, null));
-                    } else {
-                        return Future.failedFuture(
-                            new FetcherException(
-                                "Unable to fetch '" +
-                                    url +
-                                    "'. Status code: " +
-                                    response.statusCode() +
-                                    ". Message: " +
-                                    response.statusMessage(),
-                                null
-                            )
-                        );
-                    }
-                })
+                .compose(response -> handleResponse(url, response))
                 .onSuccess(promise::complete)
                 .onFailure(promise::fail);
         } catch (Exception ex) {
@@ -324,6 +306,21 @@ public class GitHubFetcher implements FilesFetcher {
         }
 
         return promise.future().toCompletionStage().toCompletableFuture();
+    }
+
+    private Future<Buffer> handleResponse(String url, HttpClientResponse response) {
+        if (response.statusCode() == HttpStatusCode.OK_200) {
+            return response.body();
+        } else if (response.statusCode() == HttpStatusCode.NOT_FOUND_404) {
+            return Future.failedFuture(new ResourceNotFoundException("Unable to fetch '" + url, null));
+        } else {
+            return Future.failedFuture(
+                new FetcherException(
+                    "Unable to fetch '" + url + "'. Status code: " + response.statusCode() + ". Message: " + response.statusMessage(),
+                    null
+                )
+            );
+        }
     }
 
     public void setVertx(Vertx vertx) {

--- a/src/test/java/io/gravitee/fetcher/github/GitHubFetcherTest.java
+++ b/src/test/java/io/gravitee/fetcher/github/GitHubFetcherTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.fetcher.github;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.gravitee.fetcher.api.FetcherException;
+import io.gravitee.fetcher.api.ResourceNotFoundException;
+import io.vertx.core.Vertx;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * @author GraviteeSource Team
+ */
+class GitHubFetcherTest {
+
+    @RegisterExtension
+    static WireMockExtension wiremock = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+    private Vertx vertx;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        vertx.close().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void should_throw_resource_not_found_without_wrapping_when_response_is_404() {
+        wiremock.stubFor(get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(aResponse().withStatus(404)));
+
+        GitHubFetcher fetcher = fetcher(10_000);
+
+        assertThatThrownBy(fetcher::fetch)
+            .isInstanceOf(ResourceNotFoundException.class)
+            .hasMessageContaining("Unable to fetch")
+            .hasNoCause();
+    }
+
+    @Test
+    void should_expose_original_cause_instead_of_async_wrapper_when_fetch_fails() {
+        wiremock.stubFor(get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(aResponse().withStatus(500)));
+
+        GitHubFetcher fetcher = fetcher(10_000);
+
+        assertThatThrownBy(fetcher::fetch)
+            .isInstanceOf(FetcherException.class)
+            .hasCauseInstanceOf(FetcherException.class)
+            .cause()
+            .isNotInstanceOf(CompletionException.class);
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void should_fail_fast_when_connection_is_closed_while_reading_response() {
+        wiremock.stubFor(
+            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(
+                aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)
+            )
+        );
+
+        GitHubFetcher fetcher = fetcher(10_000);
+
+        assertThatThrownBy(fetcher::fetch).isInstanceOf(FetcherException.class);
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void should_fail_when_connection_stalls_while_reading_body() {
+        wiremock.stubFor(
+            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"key\": \"value\"}").withChunkedDribbleDelay(20, 20_000)
+            )
+        );
+
+        GitHubFetcher fetcher = fetcher(500);
+
+        assertThatThrownBy(fetcher::fetch).isInstanceOf(FetcherException.class);
+    }
+
+    private GitHubFetcher fetcher(int timeoutMs) {
+        GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
+        config.setOwner("owner");
+        config.setRepository("myrepo");
+        config.setFilepath("/path/to/file");
+        config.setGithubUrl(wiremock.baseUrl());
+        config.setBranchOrTag("sha1");
+        GitHubFetcher fetcher = new GitHubFetcher(config);
+        ReflectionTestUtils.setField(fetcher, "httpClientTimeout", timeoutMs);
+        fetcher.setVertx(vertx);
+        return fetcher;
+    }
+}

--- a/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FetchTest.java
+++ b/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FetchTest.java
@@ -55,8 +55,9 @@ class GitHubFetcher_FetchTest {
     @Test
     public void shouldNotFetchWithoutContent() throws FetcherException {
         wiremock.stubFor(
-            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"key\": \"value\"}"))
+            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"key\": \"value\"}")
+            )
         );
         GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
         config.setOwner("owner");
@@ -91,8 +92,9 @@ class GitHubFetcher_FetchTest {
     @Test
     public void shouldThrowExceptionIfContentNotBase64() throws Exception {
         wiremock.stubFor(
-            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"content\": \"not base64 content\"}"))
+            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"content\": \"not base64 content\"}")
+            )
         );
         GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
         config.setOwner("owner");
@@ -111,8 +113,9 @@ class GitHubFetcher_FetchTest {
         String encoded = Base64.getEncoder().encodeToString(content.getBytes());
 
         wiremock.stubFor(
-            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"content\": \"" + encoded + "\"}"))
+            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"content\": \"" + encoded + "\"}")
+            )
         );
         GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
         config.setOwner("owner");
@@ -136,8 +139,9 @@ class GitHubFetcher_FetchTest {
     @Test
     public void shouldThrowExceptionWhenStatusNot200() throws Exception {
         wiremock.stubFor(
-            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1"))
-                .willReturn(aResponse().withStatus(401).withBody("{\n" + "  \"message\": \"401 Unauthorized\"\n" + "}"))
+            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(
+                aResponse().withStatus(401).withBody("{\n" + "  \"message\": \"401 Unauthorized\"\n" + "}")
+            )
         );
         GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
         config.setOwner("owner");

--- a/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_TreeTest.java
+++ b/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_TreeTest.java
@@ -39,8 +39,9 @@ class GitHubFetcher_TreeTest {
     @Test
     public void shouldNotTreeWithoutContent() throws FetcherException {
         wiremock.stubFor(
-            get(urlEqualTo("/repos/owner/myrepo/git/trees/sha1?recursive=1"))
-                .willReturn(aResponse().withStatus(200).withBody("{\"truncated\": \"false\"}"))
+            get(urlEqualTo("/repos/owner/myrepo/git/trees/sha1?recursive=1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"truncated\": \"false\"}")
+            )
         );
         GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
         config.setOwner("owner");
@@ -94,14 +95,13 @@ class GitHubFetcher_TreeTest {
 
         assertThat(tree).isNotEmpty();
         assertThat(tree).hasSize(5);
-        assertThat(tree)
-            .contains(
-                "/path/to/file/swagger.yml",
-                "/path/to/file/doc.md",
-                "/path/to/file/doc2.MD",
-                "/path/to/file/doc2.UNKNOWN",
-                "/path/to/file/subpath/doc.md"
-            );
+        assertThat(tree).contains(
+            "/path/to/file/swagger.yml",
+            "/path/to/file/doc.md",
+            "/path/to/file/doc2.MD",
+            "/path/to/file/doc2.UNKNOWN",
+            "/path/to/file/subpath/doc.md"
+        );
     }
 
     @Test
@@ -123,23 +123,23 @@ class GitHubFetcher_TreeTest {
 
         assertThat(tree).isNotEmpty();
         assertThat(tree).hasSize(7);
-        assertThat(tree)
-            .contains(
-                "/path/to/file/swagger.yml",
-                "/path/to/file/doc.md",
-                "/path/to/file/doc2.MD",
-                "/path/to/file/doc2.UNKNOWN",
-                "/path/to/file/subpath/doc.md",
-                "/CONTRIBUTING.md",
-                "/path/not/to/file/doc.md"
-            );
+        assertThat(tree).contains(
+            "/path/to/file/swagger.yml",
+            "/path/to/file/doc.md",
+            "/path/to/file/doc2.MD",
+            "/path/to/file/doc2.UNKNOWN",
+            "/path/to/file/subpath/doc.md",
+            "/CONTRIBUTING.md",
+            "/path/not/to/file/doc.md"
+        );
     }
 
     @Test
     public void shouldThrowExceptionWhenStatusNot200() throws Exception {
         wiremock.stubFor(
-            get(urlEqualTo("/repos/owner/myrepo/git/trees/sha1?recursive=1"))
-                .willReturn(aResponse().withStatus(401).withBody("{\n" + "  \"message\": \"401 Unauthorized\"\n" + "}"))
+            get(urlEqualTo("/repos/owner/myrepo/git/trees/sha1?recursive=1")).willReturn(
+                aResponse().withStatus(401).withBody("{\n" + "  \"message\": \"401 Unauthorized\"\n" + "}")
+            )
         );
         GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
         config.setOwner("owner");
@@ -153,93 +153,92 @@ class GitHubFetcher_TreeTest {
         assertThatThrownBy(fetcher::files).isInstanceOf(FetcherException.class).hasMessageContaining("Unable to fetch GitHub content (");
     }
 
-    private final String treeResponse =
-        """
-                    {
-                        "sha": "28bd3de3c32304841eb69d80079ffcc447f9ce6f",
-                        "url": "https://api.github.com/repos/owner/myrepo/git/trees/28bd3de3c32304841eb69d80079ffcc447f9ce6f",
-                        "tree": [
-                            {
-                                "path": ".gitignore",
-                                "mode": "100644",
-                                "type": "blob",
-                                "sha": "a05ec7b1a209b7bc47575bf2fea9b2b4396c0bc4",
-                                "size": 480,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/a05ec7b1a209b7bc47575bf2fea9b2b4396c0bc4"
-                            },
-                            {
-                                "path": "CONTRIBUTING.md",
-                                "mode": "100644",
-                                "type": "blob",
-                                "sha": "ae2062778d56d2cf8a52bd5047555ecba3e6b6df",
-                                "size": 3351,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/ae2062778d56d2cf8a52bd5047555ecba3e6b6df"
-                            },
-                            {
-                                "path": "path/to/file/swagger.yml",
-                                "mode": "100644",
-                                "type": "blob",
-                                "sha": "05569e2afcbcb85f461e311b332f4e30cff21a6a",
-                                "size": 12,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/05569e2afcbcb85f461e311b332f4e30cff21a6a"
-                            },
-                            {
-                                "path": "path/to/file/doc.md",
-                                "mode": "100644",
-                                "type": "blob",
-                                "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
-                                "size": 11358,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
-                            },
-                            {
-                                "path": "path/to/file/",
-                                "mode": "100644",
-                                "type": "tree",
-                                "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
-                                "size": 11358,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
-                            },
-                            {
-                                "path": "path/to/file/doc2.MD",
-                                "mode": "100644",
-                                "type": "blob",
-                                "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
-                                "size": 11358,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
-                            },
-                            {
-                                "path": "path/to/file/doc2.UNKNOWN",
-                                "mode": "100644",
-                                "type": "blob",
-                                "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
-                                "size": 11358,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
-                            },
-                            {
-                                "path": "path/not/to/file/doc.md",
-                                "mode": "100644",
-                                "type": "blob",
-                                "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
-                                "size": 11358,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
-                            },
-                            {
-                                "path": "path/to/file/subpath/",
-                                "mode": "100644",
-                                "type": "tree",
-                                "sha": "e3958323e580277dc7394fa5b148afbb053e0105",
-                                "size": 1208,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/e3958323e580277dc7394fa5b148afbb053e0105"
-                            },
-                            {
-                                "path": "path/to/file/subpath/doc.md",
-                                "mode": "100644",
-                                "type": "blob",
-                                "sha": "e3958323e580277dc7394fa5b148afbb053e0105",
-                                "size": 1208,
-                                "url": "https://api.github.com/repos/owner/myrepo/git/blobs/e3958323e580277dc7394fa5b148afbb053e0105"
-                            }
-                        ],
-                        "truncated": false\
-                    }""";
+    private final String treeResponse = """
+        {
+            "sha": "28bd3de3c32304841eb69d80079ffcc447f9ce6f",
+            "url": "https://api.github.com/repos/owner/myrepo/git/trees/28bd3de3c32304841eb69d80079ffcc447f9ce6f",
+            "tree": [
+                {
+                    "path": ".gitignore",
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": "a05ec7b1a209b7bc47575bf2fea9b2b4396c0bc4",
+                    "size": 480,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/a05ec7b1a209b7bc47575bf2fea9b2b4396c0bc4"
+                },
+                {
+                    "path": "CONTRIBUTING.md",
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": "ae2062778d56d2cf8a52bd5047555ecba3e6b6df",
+                    "size": 3351,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/ae2062778d56d2cf8a52bd5047555ecba3e6b6df"
+                },
+                {
+                    "path": "path/to/file/swagger.yml",
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": "05569e2afcbcb85f461e311b332f4e30cff21a6a",
+                    "size": 12,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/05569e2afcbcb85f461e311b332f4e30cff21a6a"
+                },
+                {
+                    "path": "path/to/file/doc.md",
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
+                    "size": 11358,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
+                },
+                {
+                    "path": "path/to/file/",
+                    "mode": "100644",
+                    "type": "tree",
+                    "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
+                    "size": 11358,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
+                },
+                {
+                    "path": "path/to/file/doc2.MD",
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
+                    "size": 11358,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
+                },
+                {
+                    "path": "path/to/file/doc2.UNKNOWN",
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
+                    "size": 11358,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
+                },
+                {
+                    "path": "path/not/to/file/doc.md",
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": "8f71f43fee3f78649d238238cbde51e6d7055c82",
+                    "size": 11358,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/8f71f43fee3f78649d238238cbde51e6d7055c82"
+                },
+                {
+                    "path": "path/to/file/subpath/",
+                    "mode": "100644",
+                    "type": "tree",
+                    "sha": "e3958323e580277dc7394fa5b148afbb053e0105",
+                    "size": 1208,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/e3958323e580277dc7394fa5b148afbb053e0105"
+                },
+                {
+                    "path": "path/to/file/subpath/doc.md",
+                    "mode": "100644",
+                    "type": "blob",
+                    "sha": "e3958323e580277dc7394fa5b148afbb053e0105",
+                    "size": 1208,
+                    "url": "https://api.github.com/repos/owner/myrepo/git/blobs/e3958323e580277dc7394fa5b148afbb053e0105"
+                }
+            ],
+            "truncated": false\
+        }""";
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-14628

**Description**

Migrate the fetcher to **Vert.x 5** to fix `NoSuchMethodError`: `HttpClientOptions.setMaxPoolSize(int)` on APIM 4.12 (runtime upgraded to Vert.x 5): bump to gravitee-bom 9.x and replace the removed pool/request APIs with `PoolOptions` + `request.send()`, mirroring the **gravitee-fetcher-http** 3.0.0 migration.

Breaking change: the plugin now requires an APIM runtime on Vert.x 5 (≥ 4.12). Also switches logging to @CustomLog (separate commit).
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-fix-vertx-fetcher-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-github/3.0.0-fix-vertx-fetcher-SNAPSHOT/gravitee-fetcher-github-3.0.0-fix-vertx-fetcher-SNAPSHOT.zip)
  <!-- Version placeholder end -->
