### PR TITLE
fix: normalize filepath and clarify not-found error

### DIFF
--- a/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
+++ b/src/main/java/io/gravitee/fetcher/github/GitHubFetcher.java
@@ -132,10 +132,7 @@ public class GitHubFetcher implements FilesFetcher {
             if (truncated != null && !truncated.asBoolean(false)) {
                 JsonNode rawTree = jsonNode.get("tree");
                 if (rawTree != null && rawTree.isArray()) {
-                    String filepath = gitHubFetcherConfiguration.getFilepath().trim();
-                    if (filepath.startsWith("/")) {
-                        filepath = filepath.replaceFirst("/", "");
-                    }
+                    String filepath = normalizeFilepath(gitHubFetcherConfiguration.getFilepath());
                     ArrayNode tree = (ArrayNode) rawTree;
                     Iterator<JsonNode> elements = tree.elements();
                     while (elements.hasNext()) {
@@ -189,11 +186,34 @@ public class GitHubFetcher implements FilesFetcher {
             gitHubFetcherConfiguration.getOwner() +
             "/" +
             gitHubFetcherConfiguration.getRepository() +
-            "/contents" +
-            gitHubFetcherConfiguration.getFilepath() +
+            "/contents/" +
+            normalizeFilepath(gitHubFetcherConfiguration.getFilepath()) +
             (gitHubFetcherConfiguration.getBranchOrTag() != null && !gitHubFetcherConfiguration.getBranchOrTag().isEmpty()
                     ? ("?ref=" + gitHubFetcherConfiguration.getBranchOrTag())
                     : "")
+        );
+    }
+
+    /** Accepts both filepath forms (with or without leading slash); never persisted back to the configuration. */
+    private static String normalizeFilepath(String filepath) {
+        return filepath == null ? "" : filepath.trim().replaceAll("^/+", "");
+    }
+
+    private String buildNotFoundMessage(String url) {
+        String ref = gitHubFetcherConfiguration.getBranchOrTag() != null && !gitHubFetcherConfiguration.getBranchOrTag().isEmpty()
+            ? gitHubFetcherConfiguration.getBranchOrTag()
+            : "master";
+        return (
+            "Unable to fetch file '" +
+            gitHubFetcherConfiguration.getFilepath() +
+            "' from GitHub repository '" +
+            gitHubFetcherConfiguration.getOwner() +
+            "/" +
+            gitHubFetcherConfiguration.getRepository() +
+            "' (ref: " +
+            ref +
+            "): resource not found. Requested URL: " +
+            url
         );
     }
 
@@ -312,7 +332,7 @@ public class GitHubFetcher implements FilesFetcher {
         if (response.statusCode() == HttpStatusCode.OK_200) {
             return response.body();
         } else if (response.statusCode() == HttpStatusCode.NOT_FOUND_404) {
-            return Future.failedFuture(new ResourceNotFoundException("Unable to fetch '" + url, null));
+            return Future.failedFuture(new ResourceNotFoundException(buildNotFoundMessage(url), null));
         } else {
             return Future.failedFuture(
                 new FetcherException(

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -30,7 +30,7 @@
         },
         "filepath": {
             "title": "Filepath",
-            "description": "The path to the file to fetch (e.g. /docs/main/README.md). Required if importing a single file.",
+            "description": "The path to the file to fetch (e.g. docs/main/README.md). Required if importing a single file.",
             "type": "string"
         },
         "username": {

--- a/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FilepathNormalizationTest.java
+++ b/src/test/java/io/gravitee/fetcher/github/GitHubFetcher_FilepathNormalizationTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.fetcher.github;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.gravitee.fetcher.api.Resource;
+import io.gravitee.fetcher.api.ResourceNotFoundException;
+import io.vertx.core.Vertx;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class GitHubFetcher_FilepathNormalizationTest {
+
+    @RegisterExtension
+    static WireMockExtension wiremock = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+    private Vertx vertx;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        vertx.close().toCompletionStage().toCompletableFuture().get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    void should_fetch_content_when_filepath_has_no_leading_slash() throws Exception {
+        stubContent();
+
+        GitHubFetcher fetcher = fetcher("path/to/file");
+        Resource resource = fetcher.fetch();
+
+        assertThat(resource).isNotNull();
+        assertThat(new String(resource.getContent().readAllBytes())).isEqualTo("Gravitee.io is awesome!");
+    }
+
+    @Test
+    void should_include_filepath_repository_and_ref_in_not_found_message() {
+        wiremock.stubFor(get(urlEqualTo("/repos/owner/myrepo/contents/path/to/unknown?ref=sha1")).willReturn(aResponse().withStatus(404)));
+
+        GitHubFetcher fetcher = fetcher("/path/to/unknown");
+
+        assertThatThrownBy(fetcher::fetch)
+            .isInstanceOf(ResourceNotFoundException.class)
+            .hasMessageContaining("Unable to fetch file '/path/to/unknown'")
+            .hasMessageContaining("owner/myrepo")
+            .hasMessageContaining("ref: sha1");
+    }
+
+    private void stubContent() {
+        String encodedContent = Base64.getEncoder().encodeToString("Gravitee.io is awesome!".getBytes());
+        wiremock.stubFor(
+            get(urlEqualTo("/repos/owner/myrepo/contents/path/to/file?ref=sha1")).willReturn(
+                aResponse().withStatus(200).withBody("{\"content\": \"" + encodedContent + "\"}")
+            )
+        );
+    }
+
+    private GitHubFetcher fetcher(String filepath) {
+        GitHubFetcherConfiguration config = new GitHubFetcherConfiguration();
+        config.setOwner("owner");
+        config.setRepository("myrepo");
+        config.setFilepath(filepath);
+        config.setGithubUrl(wiremock.baseUrl());
+        config.setBranchOrTag("sha1");
+        GitHubFetcher fetcher = new GitHubFetcher(config);
+        ReflectionTestUtils.setField(fetcher, "httpClientTimeout", 10_000);
+        ReflectionTestUtils.setField(fetcher, "mapper", new ObjectMapper());
+        fetcher.setVertx(vertx);
+        return fetcher;
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/PORTAL-55

**Description**

Documentation fetchers handled the filepath leading slash inconsistently (one form worked, the other failed with an opaque error, and the rule differed between plugins). Align this plugin with the others: accept the filepath with or without a leading slash, and raise an explicit not-found error (file, repository, ref) when the file does not exist.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.1-fix-doc-filepath-normalization-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/fetcher/gravitee-fetcher-github/3.0.1-fix-doc-filepath-normalization-SNAPSHOT/gravitee-fetcher-github-3.0.1-fix-doc-filepath-normalization-SNAPSHOT.zip)
  <!-- Version placeholder end -->
